### PR TITLE
Update clic tests

### DIFF
--- a/isa/rv64mi/Makefrag
+++ b/isa/rv64mi/Makefrag
@@ -12,5 +12,6 @@ rv64mi_sc_tests = \
 	ma_addr \
 	scall \
 	sbreak \
+	clic \
 
 rv64mi_p_tests = $(addprefix rv64mi-p-, $(rv64mi_sc_tests))

--- a/isa/rv64mi/Makefrag
+++ b/isa/rv64mi/Makefrag
@@ -13,5 +13,6 @@ rv64mi_sc_tests = \
 	scall \
 	sbreak \
 	clic \
+	clic-multiple \
 
 rv64mi_p_tests = $(addprefix rv64mi-p-, $(rv64mi_sc_tests))

--- a/isa/rv64mi/clic-multiple.S
+++ b/isa/rv64mi/clic-multiple.S
@@ -1,0 +1,224 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# clic-multiple.S
+#-----------------------------------------------------------------------------
+#
+# Test clic.
+#
+# Queues two software interrupts with different interrupt levels. The lower
+# level interrupt is queued first. Then raises the threshold to a level which is
+# between those two interrupts. Only the latter interrupt should fire and be
+# handled.
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+#define xstr(s) str(s)
+#define str(s) s
+#define CLIC_BASE                     0x50000000
+#define CLIC_CLICCFG_REG              (CLIC_BASE + 0x0)
+#define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
+#define CLIC_CLICINT_IP_OFFSET        (0)
+#define CLIC_CLICINT_IP_MASK          (1)
+#define CLIC_CLICINT_IE_OFFSET        (7)
+#define CLIC_CLICINT_IE_MASK          (1)
+#define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
+#define CLIC_CLICINT_ATTR_SHV_MASK    (1)
+#define CLIC_CLICINT_ATTR_TRIG_OFFSET (17)
+#define CLIC_CLICINT_ATTR_TRIG_MASK   (0x3)
+#define CLIC_CLICINT_ATTR_MODE_OFFSET (22)
+#define CLIC_CLICINT_ATTR_MODE_MASK   (0x3)
+#define CLIC_CLICINT_CTL_OFFSET       (24)
+#define CLIC_CLICINT_CTL_MASK         (0xff)
+
+#define MINTTHRESH                    (0x347)
+#define MTVT                          (0x307)
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  .macro clic_enable_irq id ctl
+
+  # Set shv of irq
+  li   t0, CLIC_CLICINT_REG(\id)
+  li   t1, 1 << CLIC_CLICINT_ATTR_SHV_OFFSET
+  sw   t1, 0(t0)
+
+  # set trigger type to edge-triggered of irq
+  li   t0, CLIC_CLICINT_REG(\id)
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_ATTR_TRIG_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  # enable irq via SW by writing to clicintip
+  li   t0, CLIC_CLICINT_REG(\id)
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IP_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  # set interrupt level and priority for interrupt
+  li   t0, CLIC_CLICINT_REG(\id)
+  lw   t1, 0(t0)
+  li   t2, \ctl << CLIC_CLICINT_CTL_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  # enable interrupt
+  li   t0, CLIC_CLICINT_REG(\id)
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IE_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  .endm
+
+
+  .align 2
+  .option norvc
+
+  li TESTNUM, 2
+1:
+  # Enable interrupts (set mstatus.mie)
+  csrsi mstatus, 0x8
+
+  # Activate CLIC mode
+  la t0, mtvec_handler_fail
+  ori t0, t0, 0x3
+  csrrw s0, mtvec, t0
+
+  # Write mtvt base
+  la t0, mtvt_handler
+  csrw MTVT, t0
+
+  # set number of bits for level encoding
+  li   t0, CLIC_CLICCFG_REG
+  li   t1, 0x4 << 1
+  sw   t1, 0(t0)
+
+  # raise interrupt threshold to max and check that the interrupt doesn't fire yet
+  li   a0, 0x1
+  li   t0, 0xff
+  csrw MINTTHRESH, t0
+
+  clic_enable_irq 31 0xaa
+
+  clic_enable_irq 30 0xcc
+
+  # wait
+  li t0, 500
+1:
+  addi t0, t0, -1
+  bnez t0, 1b
+
+  # lower interrupt threshold (interrupt 30 should happen)
+  li   a0, 30
+  li   t0, 0xbb
+  csrw MINTTHRESH, t0
+
+  # wait
+  li t0, 500
+2:
+  addi t0, t0, -1
+  bnez t0, 2b
+
+  # lower interrupt threshold (interrupt 31 should happen)
+  li   a0, 31
+  li   t0, 0x0
+  csrw MINTTHRESH, t0
+
+  # wait
+  li t0, 500
+3:
+  addi t0, t0, -1
+  bnez t0, 3b
+
+  j fail_restore
+
+pass_restore:
+  csrw mtvec, s0
+  j pass
+
+fail_restore:
+  csrw mtvec, s0
+  j fail
+
+thirty:
+  # a0!=30: we should not get here, fail. else: we expect to get here, pass.
+  addi a0, a0, -30
+  bnez a0, fail_restore
+  li a0, 0
+  mret
+
+thirtyone:
+  # a0!=31: we should not get here, fail. else: we expect to get here, pass.
+  addi a0, a0, -31
+  bnez a0, fail_restore
+  li a0, 0
+  j pass_restore
+
+  TEST_PASSFAIL
+
+  .align 8
+  .global mtvt_handler
+mtvt_handler:
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j thirty
+  j thirtyone
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+
+
+  .align 8
+  .global mtvec_handler_fail
+mtvec_handler_fail:
+  # Restore mtvec and fail
+  csrw mtvec, s0
+  j fail
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/isa/rv64mi/clic-multiple.S
+++ b/isa/rv64mi/clic-multiple.S
@@ -21,7 +21,7 @@
 #define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
 #define CLIC_CLICINT_IP_OFFSET        (0)
 #define CLIC_CLICINT_IP_MASK          (1)
-#define CLIC_CLICINT_IE_OFFSET        (7)
+#define CLIC_CLICINT_IE_OFFSET        (8)
 #define CLIC_CLICINT_IE_MASK          (1)
 #define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
 #define CLIC_CLICINT_ATTR_SHV_MASK    (1)

--- a/isa/rv64mi/clic.S
+++ b/isa/rv64mi/clic.S
@@ -1,10 +1,10 @@
 # See LICENSE for license details.
 
 #*****************************************************************************
-# illegal.S
+# clic.S
 #-----------------------------------------------------------------------------
 #
-# Test illegal instruction trap.
+# Test clic.
 #
 
 #include "riscv_test.h"
@@ -12,12 +12,21 @@
 
 #define xstr(s) str(s)
 #define str(s) s
-#define CLIC_BASE 0x50000000
-#define CLIC_CLICCFG_REG         (CLIC_BASE + 0x0)
-#define CLIC_CLICINTIP_REG(id)   (CLIC_BASE + 0x1000 + 0x10 * id)
-#define CLIC_CLICINTIE_REG(id)   (CLIC_BASE + 0x1004 + 0x10 * id)
-#define CLIC_CLICINTATTR_REG(id) (CLIC_BASE + 0x1008 + 0x10 * id)
-#define CLIC_CLICINTCTL_REG(id)  (CLIC_BASE + 0x100c + 0x10 * id)
+#define CLIC_BASE                     0x50000000
+#define CLIC_CLICCFG_REG              (CLIC_BASE + 0x0)
+#define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
+#define CLIC_CLICINT_IP_OFFSET        (0)
+#define CLIC_CLICINT_IP_MASK          (1)
+#define CLIC_CLICINT_IE_OFFSET        (7)
+#define CLIC_CLICINT_IE_MASK          (1)
+#define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
+#define CLIC_CLICINT_ATTR_SHV_MASK    (1)
+#define CLIC_CLICINT_ATTR_TRIG_OFFSET (17)
+#define CLIC_CLICINT_ATTR_TRIG_MASK   (0x3)
+#define CLIC_CLICINT_ATTR_MODE_OFFSET (22)
+#define CLIC_CLICINT_ATTR_MODE_MASK   (0x3)
+#define CLIC_CLICINT_CTL_OFFSET       (24)
+#define CLIC_CLICINT_CTL_MASK         (0xff)
 
 RVTEST_RV64M
 RVTEST_CODE_BEGIN
@@ -40,37 +49,44 @@ RVTEST_CODE_BEGIN
   csrw 0x307, t0 # mtvt
 
   # Set shv of irq 31
-  li   t0, CLIC_CLICINTATTR_REG(31)
-  li   t1, 1
+  li   t0, CLIC_CLICINT_REG(31)
+  li   t1, 1 << CLIC_CLICINT_ATTR_SHV_OFFSET
   sw   t1, 0(t0)
 
   # set trigger type to edge-triggered
-  li   t0, CLIC_CLICINTATTR_REG(31)
+  li   t0, CLIC_CLICINT_REG(31)
   lw   t1, 0(t0)
-  ori  t1, t1, 2
+  li   t2, 1 << CLIC_CLICINT_ATTR_TRIG_OFFSET
+  or   t1, t1, t2
   sw   t1, 0(t0)
 
   # enable irq31 via SW by writing to clicintip31
-  li   t0, CLIC_CLICINTIP_REG(31)
-  li   t1, 1
-  sb   t1, 0(t0)
+  li   t0, CLIC_CLICINT_REG(31)
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IP_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
 
   # set number of bits for level encoding
   li   t0, CLIC_CLICCFG_REG
   li   t1, 0x4 << 1
-  sb   t1, 0(t0)
+  sw   t1, 0(t0)
 
   # set interrupt level and priority for interrupt 31
-  li   t0, CLIC_CLICINTCTL_REG(31)
-  li   t1, 0xaa
+  li   t0, CLIC_CLICINT_REG(31)
+  lw   t1, 0(t0)
+  li   t2, 0xaa << CLIC_CLICINT_CTL_OFFSET
+  or   t1, t1, t2
   sw   t1, 0(t0)
 
   # raise interrupt threshold to max and check that the interrupt doesn't fire yet
   li   a0, 0x1
   li   t0, 0xff
   csrw 0x347, t0 # mintthresh
-  li   t0, CLIC_CLICINTIE_REG(31)
-  li   t1, 1
+  li   t0, CLIC_CLICINT_REG(31)
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IE_OFFSET
+  or   t1, t1, t2
   sw   t1, 0(t0)
 
   # wait

--- a/isa/rv64mi/clic.S
+++ b/isa/rv64mi/clic.S
@@ -17,7 +17,7 @@
 #define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
 #define CLIC_CLICINT_IP_OFFSET        (0)
 #define CLIC_CLICINT_IP_MASK          (1)
-#define CLIC_CLICINT_IE_OFFSET        (7)
+#define CLIC_CLICINT_IE_OFFSET        (8)
 #define CLIC_CLICINT_IE_MASK          (1)
 #define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
 #define CLIC_CLICINT_ATTR_SHV_MASK    (1)

--- a/isa/rv64mi/clic.S
+++ b/isa/rv64mi/clic.S
@@ -1,0 +1,170 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# illegal.S
+#-----------------------------------------------------------------------------
+#
+# Test illegal instruction trap.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+#define xstr(s) str(s)
+#define str(s) s
+#define CLIC_BASE 0x50000000
+#define CLIC_CLICCFG_REG         (CLIC_BASE + 0x0)
+#define CLIC_CLICINTIP_REG(id)   (CLIC_BASE + 0x1000 + 0x10 * id)
+#define CLIC_CLICINTIE_REG(id)   (CLIC_BASE + 0x1004 + 0x10 * id)
+#define CLIC_CLICINTATTR_REG(id) (CLIC_BASE + 0x1008 + 0x10 * id)
+#define CLIC_CLICINTCTL_REG(id)  (CLIC_BASE + 0x100c + 0x10 * id)
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  .align 2
+  .option norvc
+
+  li TESTNUM, 2
+1:
+  # Enable interrupts (set mstatus.mie)
+  csrsi mstatus, 0x8
+
+  # Activate CLIC mode
+  la t0, mtvec_handler_fail
+  ori t0, t0, 0x3
+  csrrw s0, mtvec, t0
+
+  # Write mtvt base
+  la t0, mtvt_handler
+  csrw 0x307, t0 # mtvt
+
+  # Set shv of irq 31
+  li   t0, CLIC_CLICINTATTR_REG(31)
+  li   t1, 1
+  sw   t1, 0(t0)
+
+  # set trigger type to edge-triggered
+  li   t0, CLIC_CLICINTATTR_REG(31)
+  lw   t1, 0(t0)
+  ori  t1, t1, 2
+  sw   t1, 0(t0)
+
+  # enable irq31 via SW by writing to clicintip31
+  li   t0, CLIC_CLICINTIP_REG(31)
+  li   t1, 1
+  sb   t1, 0(t0)
+
+  # set number of bits for level encoding
+  li   t0, CLIC_CLICCFG_REG
+  li   t1, 0x4 << 1
+  sb   t1, 0(t0)
+
+  # set interrupt level and priority for interrupt 31
+  li   t0, CLIC_CLICINTCTL_REG(31)
+  li   t1, 0xaa
+  sw   t1, 0(t0)
+
+  # raise interrupt threshold to max and check that the interrupt doesn't fire yet
+  li   a0, 0x1
+  li   t0, 0xff
+  csrw 0x347, t0 # mintthresh
+  li   t0, CLIC_CLICINTIE_REG(31)
+  li   t1, 1
+  sw   t1, 0(t0)
+
+  # wait
+  li t0, 500
+1:
+  addi t0, t0, -1
+  bnez t0, 1b
+
+  # lower interrupt threshold (interrupt should happen)
+  li   a0, 0x0
+  li   t0, 0x0
+  csrw 0x347, t0 # mintthresh
+
+  # wait
+  li t0, 500
+2:
+  addi t0, t0, -1
+  bnez t0, 2b
+
+  j fail_restore
+
+pass_restore:
+  csrw mtvec, s0
+  j pass
+
+fail_restore:
+  csrw mtvec, s0
+  j fail
+
+thirtyone:
+  # a0=0: we should not get here, fail. else: we expect to get here, pass.
+  beqz a0, pass_restore
+  j fail_restore
+
+  TEST_PASSFAIL
+
+  .align 8
+  .global mtvt_handler
+mtvt_handler:
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j thirtyone
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+  j fail_restore
+
+
+  .align 8
+  .global mtvec_handler_fail
+mtvec_handler_fail:
+  # Restore mtvec and fail
+  csrw mtvec, s0
+  j fail
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END


### PR DESCRIPTION
* Fix clic test to use the memory map according to spec
* Add simple multi interrupt tests where we check whether different level interrupts are taken in the correct order